### PR TITLE
feature: add Downtown LA spot to map

### DIFF
--- a/spots.csv
+++ b/spots.csv
@@ -1,2 +1,3 @@
 github,haiku,latitude,longitude
 machikoyasuda,"Oh, Little Tokyo<br />Temples, sushi and the mall<br />Now with GA too!",34.0523,-118.239
+machikoyasuda,"Bonaventure Hotel revolving hotel bar in Downtown",34.052571, -118.256008


### PR DESCRIPTION
## Description
Added the Bonaventure Hotel revolving bar to the map with a sentence description.

## Issue
- Closes https://github.com/machikoyasuda/los-angeles-map/issues/1

## Screenshot
![screen shot 2018-01-03 at 7 44 03 pm](https://user-images.githubusercontent.com/3673236/34549560-7c154c8e-f0be-11e7-8b68-eef7f37c162d.png)
