### PR TITLE
feature: add an Outside of LA category

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,8 @@
                     neighborhoodName = neighborhood[0].feature.properties.name;
                     incrementHaikuCounts(neighborhoodName);
                   } else {
-                    console.log(point.getLatLng() + " falls outside of any known neighborhoods");
+                    neighborhoodName = "Outside of L.A."
+                    incrementHaikuCounts(neighborhoodName)
                   }
                 });
               }).addTo(map);


### PR DESCRIPTION
## Description
Adds an `Outside of LA` category in the Haiku Counts table

## Issue
- Closes https://github.com/machikoyasuda/los-angeles-map/issues/15

## Screenshot
![Uploading Screen Shot 2018-01-03 at 9.54.31 PM.png…]()

